### PR TITLE
Allow per-spider configuration Fixes #17

### DIFF
--- a/scrapy_mongodb.py
+++ b/scrapy_mongodb.py
@@ -68,16 +68,16 @@ class MongoDBPipeline(BaseItemExporter):
     # Duplicate key occurence count
     duplicate_key_count = 0
 
-    @classmethod
-    def from_crawler(cls, crawler):
-        return cls(crawler)
+    def load_spider(self, spider):
+        self.crawler = spider.crawler
+        self.settings = spider.settings
 
-    def __init__(self, crawler):
-        """ Constructor """
-        super(MongoDBPipeline, self).__init__()
-        self.settings = crawler.settings
+        # Versions prior to 0.25
+        if not getattr(spider, 'update_settings', False):
+            self.settings.setdict(spider.custom_settings or {}, priority='project')
 
-        self.crawler = crawler
+    def open_spider(self, spider):
+        self.load_spider(spider)
 
         # Configure the connection
         self.configure()


### PR DESCRIPTION
Scrapy version 0.25 (master) has per spider configuration - see [`custom_settings`](https://github.com/scrapy/scrapy/search?utf8=%E2%9C%93&q=update_settings)

This PR is consonant with that but also supports older versions by using the same property in the spider to update MongoDBPipeline settings.